### PR TITLE
Add solarcfg mobile connection helper script

### DIFF
--- a/mobile-mm/debian/Makefile
+++ b/mobile-mm/debian/Makefile
@@ -1,5 +1,5 @@
 DIST = 
-VERSION = 1.0.1-1$(if $(DIST),+$(DIST),)
+VERSION = 1.1.0-1$(if $(DIST),+$(DIST),)
 NAME = sn-mobile-mm
 PATHS = lib usr
 
@@ -17,6 +17,7 @@ deb : prep
 	-d 'systemd (>= 247)' \
 	-d 'modemmanager' \
 	-d 'socat' \
+	-d 'sn-system (>= 1.5.0)' \
 	--conflicts 'sn-pi-sixfab-3g-shield-vodafone' \
 	--conflicts 'sn-pi-mobile-shield-quectel' \
 	--replaces 'sn-pi-mobile-shield-quectel' \

--- a/mobile-mm/debian/README.md
+++ b/mobile-mm/debian/README.md
@@ -56,6 +56,25 @@ sudo systemctl start sn-mobile-mm-init
 ```
 
 
+# `solarcfg` integration
+
+This package installs a `/usr/share/solarnode/cfg.d/mobile.sh` service script so the mobile
+connection can be managed via the `solarcfg` helper (provided by the `sn-system` package):
+
+```sh
+# report connection status (operator, signal, state)
+sudo solarcfg mobile status
+# reset the connection (disable then enable the modem)
+sudo solarcfg mobile reset
+# restart the ModemManager service
+sudo solarcfg mobile restart
+```
+
+This is used by the SolarNode `net.solarnetwork.node.setup.mobile` plugin, which exposes the same
+actions to the SolarNode UI and to remote clients (such as the mobile app) via a `SystemConfigure`
+instruction with a `service` parameter of `/setup/network/mobile`.
+
+
 # Packaging
 
 This section describes how the `sn-pi-mobile-shield-usb` package is created.

--- a/mobile-mm/debian/usr/share/solarnode/cfg.d/mobile.sh
+++ b/mobile-mm/debian/usr/share/solarnode/cfg.d/mobile.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# SolarNode mobile (cellular/4G) network helper script for the sn-mobile-mm
+# package, which manages cellular connectivity via ModemManager.
+#
+# Invoked by the solarcfg wrapper:
+#
+#     solarcfg mobile <action> [args...]
+#
+# solarcfg dispatches to this script (installed as
+# /usr/share/solarnode/cfg.d/mobile.sh) with <action> as the first argument,
+# run as root via sudo.
+#
+# Supports the net.solarnetwork.node.setup.mobile plugin, which sends a
+# SystemConfigure instruction with service=/setup/network/mobile.
+#
+# Output contract (consumed by the plugin):
+#   status -> "key: value" lines. "present: true|false" indicates whether a
+#             modem exists (so whether a reset is possible); "active: true|false"
+#             indicates current connectivity; remaining lines (operator, access,
+#             signal, state) are informational.
+#   reset/restart -> human-readable result lines on STDOUT; errors on STDERR
+#             with a non-zero exit code.
+
+ACTION="$1"
+shift 2>/dev/null
+
+# return success if a modem is present
+modem_present () {
+	command -v mmcli >/dev/null 2>&1 || return 1
+	mmcli -L 2>/dev/null | grep -q '/Modem/'
+}
+
+# print connection status as "key: value" lines (present, active, then detail)
+do_status () {
+	if ! command -v mmcli >/dev/null 2>&1; then
+		echo "present: false"
+		echo "active: false"
+		echo "detail: ModemManager not installed"
+		return 0
+	fi
+	if ! modem_present; then
+		echo "present: false"
+		echo "active: false"
+		return 0
+	fi
+	local kv state op sig act
+	kv="$(mmcli -m any -K 2>/dev/null)"
+	state="$(printf '%s\n' "$kv" | sed -n 's/^modem\.generic\.state *: *//p')"
+	op="$(printf '%s\n' "$kv" | sed -n 's/^modem\.3gpp\.operator-name *: *//p')"
+	sig="$(printf '%s\n' "$kv" | sed -n 's/^modem\.generic\.signal-quality\.value *: *//p')"
+	act="$(printf '%s\n' "$kv" | sed -n 's/^modem\.generic\.access-technologies\.value\[1\] *: *//p')"
+
+	echo "present: true"
+	if [ "$state" = "connected" ]; then
+		echo "active: true"
+	else
+		echo "active: false"
+	fi
+	[ -n "$op" ] && echo "operator: $op"
+	[ -n "$act" ] && echo "access: $act"
+	[ -n "$sig" ] && echo "signal: ${sig}%"
+	[ -n "$state" ] && echo "state: $state"
+	return 0
+}
+
+# reset the mobile connection by power-cycling the radio (disable then enable)
+do_reset () {
+	if ! command -v mmcli >/dev/null 2>&1; then
+		echo "ModemManager (mmcli) not available." 1>&2
+		exit 3
+	fi
+	if ! modem_present; then
+		echo "No modem present to reset." 1>&2
+		exit 4
+	fi
+	echo "Disabling modem..."
+	mmcli -m any --disable >/dev/null 2>&1
+	sleep 2
+	echo "Enabling modem..."
+	mmcli -m any --enable >/dev/null 2>&1
+	# If the bearer does not auto-reconnect on this image, an explicit connect
+	# may be required instead, for example:
+	#   mmcli -m any --simple-connect="apn=<apn>"
+	# A stronger alternative is a full modem reset (power cycle):
+	#   mmcli -m any --reset
+	echo "Mobile connection reset requested."
+	return 0
+}
+
+# restart the mobile networking service
+do_restart () {
+	echo "Restarting ModemManager..."
+	systemctl restart ModemManager
+}
+
+case "$ACTION" in
+	status)  do_status "$@";;
+	reset)   do_reset "$@";;
+	restart) do_restart "$@";;
+	*)
+		echo "Action '${ACTION}' not supported. Use one of: status, reset, restart." 1>&2
+		exit 1
+esac

--- a/pi-mobile-shield-usb/debian/Makefile
+++ b/pi-mobile-shield-usb/debian/Makefile
@@ -1,5 +1,5 @@
 DIST = 
-VERSION = 1.1.0-1$(if $(DIST),+$(DIST),)
+VERSION = 1.2.0-1$(if $(DIST),+$(DIST),)
 NAME = sn-pi-mobile-shield-usb
 PATHS = etc lib usr
 
@@ -17,6 +17,7 @@ deb : prep
 	-d 'systemd (>= 247)' \
 	-d 'ppp (>= 2.4.9)' \
 	-d 'gpsd (>= 3.22)' \
+	-d 'sn-system (>= 1.5.0)' \
 	--conflicts 'sn-pi-sixfab-3g-shield-vodafone' \
 	--conflicts 'sn-pi-mobile-shield-quectel' \
 	--replaces 'sn-pi-mobile-shield-quectel' \

--- a/pi-mobile-shield-usb/debian/README.md
+++ b/pi-mobile-shield-usb/debian/README.md
@@ -143,6 +143,20 @@ ln -sf mode.3G-only /etc/ppp/chatscripts/mode
 ```
 
 
+# `solarcfg` integration
+
+This package installs a `/usr/share/solarnode/cfg.d/mobile.sh` service script so the mobile
+connection can be managed via the `solarcfg` helper (provided by the `sn-system` package):
+
+```sh
+# report connection status (interface, address, link state)
+sudo solarcfg mobile status
+# reset the connection (restart the PPP connection)
+sudo solarcfg mobile reset
+# restart the PPP connection service
+sudo solarcfg mobile restart
+```
+
 # Packaging
 
 This section describes how the `sn-pi-mobile-shield-usb` package is created.

--- a/pi-mobile-shield-usb/debian/usr/share/solarnode/cfg.d/mobile.sh
+++ b/pi-mobile-shield-usb/debian/usr/share/solarnode/cfg.d/mobile.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# SolarNode mobile (cellular/4G) network helper script for the
+# sn-pi-mobile-shield-usb package, which manages cellular connectivity via
+# pppd (rather than ModemManager).
+#
+# Invoked by the solarcfg wrapper:
+#
+#     solarcfg mobile <action> [args...]
+#
+# Output contract (consumed by the plugin):
+#   status -_> "key: value" lines. "present: true|false" indicates whether the
+#             PPP connection service exists (so whether a reset is possible);
+#             "active: true|false" indicates current connectivity; remaining
+#             lines (interface, address, state) are informational.
+#   reset/restart -> human-readable result lines on STDOUT; errors on STDERR
+#             with a non-zero exit code.
+
+PPPD_SERVICE="sn-mobile-shield-usb-pppd"
+NET_INTERFACE="ppp0"
+
+# honor the interface override shared with the auto-reconnect task
+DEFAULTS="/etc/default/sn-pi-mobile-shield"
+if [ -e "$DEFAULTS" ]; then
+	. "$DEFAULTS"
+fi
+
+ACTION="$1"
+shift 2>/dev/null
+
+# return success if the PPP connection service is installed
+service_present () {
+	systemctl list-unit-files "${PPPD_SERVICE}.service" 2>/dev/null \
+		| grep -q "^${PPPD_SERVICE}.service"
+}
+
+# print connection status as "key: value" lines (present, active, then detail)
+do_status () {
+	if ! service_present; then
+		echo "present: false"
+		echo "active: false"
+		echo "detail: ${PPPD_SERVICE} service not installed"
+		return 0
+	fi
+	echo "present: true"
+
+	# Get status of network interface, e.g. UP, DOWN, UNKNOWN
+	local iface_status addr
+	iface_status="$(ip -br link show 2>/dev/null | grep "^${NET_INTERFACE}" | awk '{print $2}')"
+
+	# a PPP link reports UNKNOWN when up, so treat UP and UNKNOWN as active
+	if [ "$iface_status" = "UP" ] || [ "$iface_status" = "UNKNOWN" ]; then
+		echo "active: true"
+	else
+		echo "active: false"
+	fi
+
+	echo "interface: ${NET_INTERFACE}"
+	[ -n "$iface_status" ] && echo "state: $iface_status"
+	addr="$(ip -br -4 addr show "${NET_INTERFACE}" 2>/dev/null | awk '{print $3}')"
+	[ -n "$addr" ] && echo "address: $addr"
+	return 0
+}
+
+# reset the mobile connection by restarting the PPP connection
+do_reset () {
+	if ! service_present; then
+		echo "No PPP connection service (${PPPD_SERVICE}) present to reset." 1>&2
+		exit 4
+	fi
+	echo "Restarting PPP connection (${PPPD_SERVICE})..."
+	systemctl restart "${PPPD_SERVICE}"
+	echo "Mobile connection reset requested."
+	return 0
+}
+
+# restart the mobile networking service; for pppd this is the same underlying
+# action as reset, as there is no separate management daemon
+do_restart () {
+	echo "Restarting PPP connection service (${PPPD_SERVICE})..."
+	systemctl restart "${PPPD_SERVICE}"
+}
+
+case "$ACTION" in
+	status)  do_status "$@";;
+	reset)   do_reset "$@";;
+	restart) do_restart "$@";;
+	*)
+		echo "Action '${ACTION}' not supported. Use one of: status, reset, restart." 1>&2
+		exit 1
+esac


### PR DESCRIPTION
Adds a network helper for mobile (cellular/4G) network stuff.

Leaving as a draft for now since I haven't had a good opportunity to really test this well. Will update this when I have had a good play around.